### PR TITLE
Fix port duplicate error when npm run-p command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "repository": "ssh://git@github.com/uncovertruth/newbie-training.git",
   "scripts": {
     "build": "npm run clean && run-p build:*",
-    "build:custom": "reveal-md custom.md --static docs/custom/",
+    "build:custom": "reveal-md custom.md --static docs/custom/ --port 1948",
     "build:example": "pug index.pug -P -o docs",
-    "build:tutorial": "reveal-md tutorial.md --static docs/tutorial/",
+    "build:tutorial": "reveal-md tutorial.md --static docs/tutorial/ --port 1949",
     "clean": "rimraf docs/slides docs/custom docs/tutorial",
     "lint": "textlint -c @uncovertruth/textlint-config-ja custom.md tutorial.md --cache",
     "precommit": "lint-staged",


### PR DESCRIPTION
Fix following error at run `yarn build`.
```
rendered /home/travis/build/uncovertruth/newbie-training/docs/index.html
Reveal-server started at http://localhost:1948
Reveal-server started at http://localhost:1948
events.js:167
      throw er; // Unhandled 'error' event
      ^
Error: listen EADDRINUSE :::1948
    at Server.setupListenHandle [as _listen2] (net.js:1336:14)
    at listenInCluster (net.js:1384:12)
    at Server.listen (net.js:1471:7)
    at Function.listen (/home/travis/build/uncovertruth/newbie-training/node_modules/express/lib/application.js:618:24)
    at startServer (/home/travis/build/uncovertruth/newbie-training/node_modules/reveal-md/lib/serve.js:49:22)
    at Promise (/home/travis/build/uncovertruth/newbie-training/node_modules/reveal-md/lib/featured-slide.js:35:5)
    at new Promise (<anonymous>)
    at snapshot (/home/travis/build/uncovertruth/newbie-training/node_modules/reveal-md/lib/featured-slide.js:34:10)
    at renderStaticMarkup (/home/travis/build/uncovertruth/newbie-training/node_modules/reveal-md/lib/static.js:46:15)
    at revealMarkdown (/home/travis/build/uncovertruth/newbie-training/node_modules/reveal-md/lib/index.js:17:5)
    at Object.<anonymous> (/home/travis/build/uncovertruth/newbie-training/node_modules/reveal-md/bin/cli.js:52:1)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
Emitted 'error' event at:
    at emitErrorNT (net.js:1363:8)
    at process._tickCallback (internal/process/next_tick.js:63:19)
    at Function.Module.runMain (internal/modules/cjs/loader.js:745:11)
    at startup (internal/bootstrap/node.js:266:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:596:3)
error Command failed with exit code 1.
```